### PR TITLE
Fix line number calculation

### DIFF
--- a/lib/rspec-iterm.js
+++ b/lib/rspec-iterm.js
@@ -46,7 +46,7 @@ export default {
 
   runByLine() {
     let filePath = this.activeFilePath()
-    let lineNumber = this.editor.getCursorScreenPosition().row
+    let lineNumber = this.editor.getCursorScreenPosition().row + 1
     this.execute(`${atom.config.get('rspec-iterm.rspecCommand')} ${filePath}:${lineNumber}`)
   },
 


### PR DESCRIPTION
`getCursorScreenPosition().row` is zero-indexed whereas rspec expects the line number to be 1-indexed.

P.S.: best rspec runner for atom. neato!